### PR TITLE
:sparkles: feat: 랜덤 닉네임 생성 기능 구현 (다국어 + 중복 방지)

### DIFF
--- a/src/main/java/com/oseak/myFestaBackend/common/exception/code/ClientErrorCode.java
+++ b/src/main/java/com/oseak/myFestaBackend/common/exception/code/ClientErrorCode.java
@@ -27,7 +27,8 @@ public enum ClientErrorCode implements BaseErrorCode {
 
 	// 회원가입/중복 관련
 	USER_EMAIL_DUPLICATE(HttpStatus.CONFLICT, "OSAEK-10003", "user.email.duplicate"),
-	USER_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "OSAEK-10004", "user.nickname.duplicate"),
+	USER_NICKNAME_GENERATION_ATTEMPT_EXCEEDED(HttpStatus.CONFLICT, "OSAEK-10004",
+		"user.nickname.generation_attempt_exceeded"),
 
 	// 로그인 관련
 	AUTH_CREDENTIALS_INVALID(HttpStatus.UNAUTHORIZED, "OSAEK-10005", "auth.credentials.invalid"),

--- a/src/main/java/com/oseak/myFestaBackend/entity/GeneratedNickname.java
+++ b/src/main/java/com/oseak/myFestaBackend/entity/GeneratedNickname.java
@@ -1,0 +1,37 @@
+package com.oseak.myFestaBackend.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "generated_nickname")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class GeneratedNickname {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 32, nullable = false, unique = true)
+	private String nickname;
+
+	@Column(nullable = false, updatable = false)
+	@CreationTimestamp
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/oseak/myFestaBackend/entity/NicknameAdjective.java
+++ b/src/main/java/com/oseak/myFestaBackend/entity/NicknameAdjective.java
@@ -1,0 +1,37 @@
+package com.oseak.myFestaBackend.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "nickname_adjective")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NicknameAdjective {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 10, nullable = false, unique = true)
+	private String word;
+
+	@Column(length = 10, nullable = false)
+	private String langCode;
+
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/oseak/myFestaBackend/entity/NicknameAnimal.java
+++ b/src/main/java/com/oseak/myFestaBackend/entity/NicknameAnimal.java
@@ -1,0 +1,37 @@
+package com.oseak.myFestaBackend.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "nickname_animal")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NicknameAnimal {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 10, nullable = false, unique = true)
+	private String word;
+
+	@Column(length = 10, nullable = false)
+	private String langCode;
+
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/oseak/myFestaBackend/entity/NicknameVibe.java
+++ b/src/main/java/com/oseak/myFestaBackend/entity/NicknameVibe.java
@@ -1,0 +1,37 @@
+package com.oseak.myFestaBackend.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "nickname_vibe")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NicknameVibe {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 10, nullable = false, unique = true)
+	private String word;
+
+	@Column(length = 10, nullable = false)
+	private String langCode;
+
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/oseak/myFestaBackend/generator/NicknameGenerator.java
+++ b/src/main/java/com/oseak/myFestaBackend/generator/NicknameGenerator.java
@@ -1,0 +1,125 @@
+package com.oseak.myFestaBackend.generator;
+
+import java.util.Random;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.oseak.myFestaBackend.common.exception.OsaekException;
+import com.oseak.myFestaBackend.entity.GeneratedNickname;
+import com.oseak.myFestaBackend.repository.GeneratedNicknameRepository;
+import com.oseak.myFestaBackend.repository.NicknameAdjectiveRepository;
+import com.oseak.myFestaBackend.repository.NicknameAnimalRepository;
+import com.oseak.myFestaBackend.repository.NicknameVibeRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 닉네임을 랜덤으로 조합하여 생성하는 유틸성 컴포넌트.
+ *
+ * - vibe + adjective + animal 형태로 조합된 축제 느낌의 닉네임 생성
+ * - 예: "불꽃설레는 여우", "여름빛흔들리는 고양이"
+ *
+ * - 생성된 닉네임은 `generated_nickname` 테이블에 저장 (UNIQUE 제약)
+ * - 동일한 닉네임 충돌 시 최대 30회까지 재시도
+ *
+ * - 30회 모두 실패 시, 기존 닉네임에 2자리 숫자 접미사(랜덤) 붙여 생성
+ * - 예: "불꽃설레는 여우72"
+ * - 접미사 충돌 시 무한 재시도
+ *
+ * <h2>사용 예시</h2>
+ * <pre>{@code
+ * String nickname = nicknameGenerator.generate("ko");
+ *
+ * memberRepository.save(Member.builder()
+ *     .email(email)
+ *     .nickname(nickname)
+ *     .password(passwordEncoder.encode(rawPassword))
+ *     .build());
+ * }</pre>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NicknameGenerator {
+
+	private static final int MAX_ATTEMPTS = 30;
+	private static final int MAX_NICKNAME_LENGTH = 32;
+
+	private final NicknameVibeRepository vibeRepository;
+	private final NicknameAdjectiveRepository adjectiveRepository;
+	private final NicknameAnimalRepository animalRepository;
+	private final GeneratedNicknameRepository generatedNicknameRepository;
+
+	private final Random random = new Random();
+
+	/**
+	 * 언어 코드에 따른 고유 닉네임을 생성하여 저장하고 반환한다.
+	 * 충돌 발생 시 최대 30회까지 기본 조합으로 재시도하고,
+	 * 이후에는 2자리 숫자 접미사를 붙여 중복 방지 닉네임을 만든다.
+	 *
+	 * @param langCode 언어 코드 (예: "ko", "en")
+	 * @return 생성된 고유 닉네임 문자열
+	 * @throws OsaekException 고유 닉네임 생성 실패 시
+	 */
+	@Transactional
+	public String generate(String langCode) {
+		String baseNickname = null;
+
+		// 기본 조합으로 최대 30회 시도
+		for (int i = 0; i < MAX_ATTEMPTS; i++) {
+			String nickname = buildNickname(langCode);
+
+			try {
+				generatedNicknameRepository.save(
+					GeneratedNickname.builder()
+						.nickname(nickname)
+						.build()
+				);
+
+				log.debug("[닉네임 생성] {}회 시도 후 성공 → {}", i + 1, nickname);
+				return nickname;
+
+			} catch (DataIntegrityViolationException e) {
+				log.warn("[닉네임 충돌] 중복된 닉네임 '{}', {}회 시도 중", nickname, i + 1);
+			}
+
+			baseNickname = nickname;
+		}
+
+		// fallback: 접미사 붙이기 (중복 피할 때까지 무한 시도)
+		while (true) {
+			String suffix = String.format("%02d", random.nextInt(100)); // 00~99
+			String nicknameWithSuffix = baseNickname + suffix;
+
+			// 32자 제한 초과 방지
+			if (nicknameWithSuffix.length() > MAX_NICKNAME_LENGTH) {
+				nicknameWithSuffix = nicknameWithSuffix.substring(0, MAX_NICKNAME_LENGTH);
+			}
+
+			try {
+				generatedNicknameRepository.save(
+					GeneratedNickname.builder()
+						.nickname(nicknameWithSuffix)
+						.build()
+				);
+
+				log.info("[닉네임 fallback] 접미사 '{}' 붙여 생성 성공 → {}", suffix, nicknameWithSuffix);
+				return nicknameWithSuffix;
+
+			} catch (DataIntegrityViolationException e) {
+				log.warn("[닉네임 fallback 충돌] '{}'", nicknameWithSuffix);
+			}
+		}
+	}
+
+	private String buildNickname(String langCode) {
+		String vibe = vibeRepository.findRandomByLangCode(langCode);
+		String adjective = adjectiveRepository.findRandomByLangCode(langCode);
+		String animal = animalRepository.findRandomByLangCode(langCode);
+
+		return vibe + adjective + " " + animal;
+	}
+}

--- a/src/main/java/com/oseak/myFestaBackend/repository/GeneratedNicknameRepository.java
+++ b/src/main/java/com/oseak/myFestaBackend/repository/GeneratedNicknameRepository.java
@@ -1,0 +1,20 @@
+package com.oseak.myFestaBackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.oseak.myFestaBackend.entity.GeneratedNickname;
+
+/**
+ * 생성된 닉네임(nickname)을 저장 및 중복 체크하는 Repository.
+ * 닉네임 중복 여부를 검사하고, 중복되지 않은 경우 저장한다.
+ */
+public interface GeneratedNicknameRepository extends JpaRepository<GeneratedNickname, Long> {
+
+	/**
+	 * 주어진 닉네임이 이미 사용되었는지 여부를 확인한다.
+	 *
+	 * @param nickname 생성된 닉네임 문자열
+	 * @return true: 이미 존재함, false: 사용 가능
+	 */
+	boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/oseak/myFestaBackend/repository/NicknameAdjectiveRepository.java
+++ b/src/main/java/com/oseak/myFestaBackend/repository/NicknameAdjectiveRepository.java
@@ -1,0 +1,29 @@
+package com.oseak.myFestaBackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.oseak.myFestaBackend.entity.NicknameAdjective;
+
+/**
+ * 닉네임 형용사 키워드(adjective)를 조회하는 Repository.
+ * 주어진 언어 코드(langCode)에 해당하는 형용사 키워드를 랜덤으로 1개 선택한다.
+ */
+public interface NicknameAdjectiveRepository extends JpaRepository<NicknameAdjective, Long> {
+
+	/**
+	 * 지정된 언어 코드에 해당하는 형용사 키워드 중 랜덤으로 1개를 조회한다.
+	 *
+	 * @param langCode 사용할 언어 코드 (예: "ko", "en")
+	 * @return 랜덤으로 선택된 형용사 키워드 (word)
+	 */
+	@Query(value = """
+		    SELECT word 
+		    FROM nickname_adjective 
+		    WHERE lang_code = :langCode 
+		    ORDER BY RAND() 
+		    LIMIT 1
+		""", nativeQuery = true)
+	String findRandomByLangCode(@Param("langCode") String langCode);
+}

--- a/src/main/java/com/oseak/myFestaBackend/repository/NicknameAnimalRepository.java
+++ b/src/main/java/com/oseak/myFestaBackend/repository/NicknameAnimalRepository.java
@@ -1,0 +1,29 @@
+package com.oseak.myFestaBackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.oseak.myFestaBackend.entity.NicknameAnimal;
+
+/**
+ * 닉네임 동물 키워드(animal)를 조회하는 Repository.
+ * 주어진 언어 코드(langCode)에 해당하는 동물 키워드를 랜덤으로 1개 선택한다.
+ */
+public interface NicknameAnimalRepository extends JpaRepository<NicknameAnimal, Long> {
+
+	/**
+	 * 지정된 언어 코드에 해당하는 동물 키워드 중 랜덤으로 1개를 조회한다.
+	 *
+	 * @param langCode 사용할 언어 코드 (예: "ko", "en")
+	 * @return 랜덤으로 선택된 동물 키워드 (word)
+	 */
+	@Query(value = """
+		    SELECT word 
+		    FROM nickname_animal 
+		    WHERE lang_code = :langCode 
+		    ORDER BY RAND() 
+		    LIMIT 1
+		""", nativeQuery = true)
+	String findRandomByLangCode(@Param("langCode") String langCode);
+}

--- a/src/main/java/com/oseak/myFestaBackend/repository/NicknameVibeRepository.java
+++ b/src/main/java/com/oseak/myFestaBackend/repository/NicknameVibeRepository.java
@@ -1,0 +1,29 @@
+package com.oseak.myFestaBackend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.oseak.myFestaBackend.entity.NicknameVibe;
+
+/**
+ * 닉네임 분위기 키워드(vibe)를 조회하는 Repository.
+ * 주어진 언어 코드(langCode)에 해당하는 분위기 키워드를 랜덤으로 1개 선택한다.
+ */
+public interface NicknameVibeRepository extends JpaRepository<NicknameVibe, Long> {
+
+	/**
+	 * 지정된 언어 코드에 해당하는 분위기 키워드 중 랜덤으로 1개를 조회한다.
+	 *
+	 * @param langCode 사용할 언어 코드 (예: "ko", "en")
+	 * @return 랜덤으로 선택된 분위기 키워드 (word)
+	 */
+	@Query(value = """
+		    SELECT word 
+		    FROM nickname_vibe 
+		    WHERE lang_code = :langCode 
+		    ORDER BY RAND() 
+		    LIMIT 1
+		""", nativeQuery = true)
+	String findRandomByLangCode(@Param("langCode") String langCode);
+}

--- a/src/main/resources/errors_en.properties
+++ b/src/main/resources/errors_en.properties
@@ -12,7 +12,7 @@ user.id.not_found=The specified user was not found.
 user.email.not_found=The specified email is not registered.
 # 회원가입/중복 관련
 user.email.duplicate=This email is already in use.
-user.nickname.duplicate=This nickname is already in use.
+user.nickname.generation_attempt_exceeded=Failed to generate nickname. Maximum attempts exceeded due to duplication.
 # 로그인 관련
 auth.credentials.invalid=Invalid email or password.
 auth.account.disabled=This account has been disabled.

--- a/src/main/resources/errors_ko.properties
+++ b/src/main/resources/errors_ko.properties
@@ -18,7 +18,7 @@ user.id.not_found=해당 사용자를 찾을 수 없습니다.
 user.email.not_found=등록되지 않은 이메일입니다.
 # 회원가입/중복 관련
 user.email.duplicate=이미 사용 중인 이메일입니다.
-user.nickname.duplicate=이미 사용 중인 닉네임입니다.
+user.nickname.generation_attempt_exceeded=닉네임을 생성할 수 없습니다. 중복으로 인해 최대 시도 횟수를 초과했습니다.
 # 로그인 관련
 auth.credentials.invalid=이메일 또는 비밀번호가 올바르지 않습니다.
 auth.account.disabled=비활성화된 계정입니다.

--- a/src/test/java/com/oseak/myFestaBackend/generator/NicknameGeneratorTest.java
+++ b/src/test/java/com/oseak/myFestaBackend/generator/NicknameGeneratorTest.java
@@ -1,0 +1,77 @@
+package com.oseak.myFestaBackend.generator;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.oseak.myFestaBackend.entity.GeneratedNickname;
+import com.oseak.myFestaBackend.repository.GeneratedNicknameRepository;
+import com.oseak.myFestaBackend.repository.NicknameAdjectiveRepository;
+import com.oseak.myFestaBackend.repository.NicknameAnimalRepository;
+import com.oseak.myFestaBackend.repository.NicknameVibeRepository;
+
+public class NicknameGeneratorTest {
+
+	private NicknameGenerator generator;
+	private NicknameVibeRepository vibeRepo;
+	private NicknameAdjectiveRepository adjRepo;
+	private NicknameAnimalRepository animalRepo;
+	private GeneratedNicknameRepository genRepo;
+
+	@BeforeEach
+	void setUp() {
+		vibeRepo = mock(NicknameVibeRepository.class);
+		adjRepo = mock(NicknameAdjectiveRepository.class);
+		animalRepo = mock(NicknameAnimalRepository.class);
+		genRepo = mock(GeneratedNicknameRepository.class);
+
+		generator = new NicknameGenerator(vibeRepo, adjRepo, animalRepo, genRepo);
+	}
+
+	@Test
+	@DisplayName("닉네임이 정상적으로 생성되어 저장된다")
+	void generateNickname_success() {
+		// given
+		when(vibeRepo.findRandomByLangCode("ko")).thenReturn("여름빛");
+		when(adjRepo.findRandomByLangCode("ko")).thenReturn("웃는");
+		when(animalRepo.findRandomByLangCode("ko")).thenReturn("고양이");
+
+		when(genRepo.save(any())).thenReturn(
+			new GeneratedNickname(1L, "여름빛웃는 고양이", LocalDateTime.now())
+		);
+
+		// when
+		String nickname = generator.generate("ko");
+
+		// then
+		assertThat(nickname).isEqualTo("여름빛웃는 고양이");
+	}
+
+	@Test
+	@DisplayName("기본 닉네임이 30회 모두 충돌 시, 랜덤 숫자 접미사를 붙여 저장된다")
+	void generateNickname_withSuffixFallback_success() {
+		// given
+		when(vibeRepo.findRandomByLangCode("ko")).thenReturn("불꽃");
+		when(adjRepo.findRandomByLangCode("ko")).thenReturn("설레는");
+		when(animalRepo.findRandomByLangCode("ko")).thenReturn("여우");
+
+		// 기본 닉네임 30회 충돌
+		when(genRepo.save(any()))
+			.thenThrow(new DataIntegrityViolationException("중복 오류")) // 1~30회 충돌
+			.thenThrow(new DataIntegrityViolationException("중복 오류")) // fallback 1 충돌
+			.thenReturn(new GeneratedNickname(31L, "불꽃설레는 여우42", LocalDateTime.now())); // fallback 2 성공
+
+		// when
+		String nickname = generator.generate("ko");
+
+		// then
+		assertThat(nickname).startsWith("불꽃설레는 여우");
+		assertThat(nickname).hasSizeLessThanOrEqualTo(32);
+	}
+}


### PR DESCRIPTION
| 임시 PR - 프로필 사진 생성 기능 미구현 

# 닉네임 자동 생성 기능 추가
### 닉네임 생성 방식
- `vibe + adjective + animal` 형태로 랜덤 조합
- 예: `여름빛웃는 고양이`, `불꽃설레는 여우`

### 중복 방지 로직
- `generated_nickname` 테이블에 유니크하게 저장
- 중복 발생 시 최대 30회까지 재시도
- 30회 초과 시, **랜덤 2자리 숫자 접미사** 붙여 고유한 닉네임 생성
  - 예: `불꽃설레는 여우 17`

### 다국어 대응
- 각 키워드(`vibe`, `adjective`, `animal`)에 `lang_code` 필드 적용
- `ko`, `en` 등 언어 코드 기반 키워드 랜덤 조회

### 구성
- 닉네임 키워드 엔티티 및 리포지토리 추가
  - `NicknameVibe`, `NicknameAdjective`, `NicknameAnimal`, `GeneratedNickname`
- 닉네임 생성 로직: `NicknameGenerator.java`

### 국제화 및 예외 코드
- 충돌 횟수 초과 예외: `user.nickname.generation_attempt_exceeded`
- 다국어 메시지 파일에 한글/영문 메시지 추가
  - `errors_ko.properties`
  - `errors_en.properties`

### 테스트 코드 작성
- 정상 생성 테스트
- 충돌 반복 시 fallback 생성 테스트
