### PR TITLE
feat: 축제 상세 조회 API 구현 및 축제 검색 API반환타입 수정

### DIFF
--- a/src/main/java/com/oseak/myFestaBackend/common/exception/code/ClientErrorCode.java
+++ b/src/main/java/com/oseak/myFestaBackend/common/exception/code/ClientErrorCode.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
  *   <li><b>도메인코드 (2자리)</b>: 10 = 회원/인증 도메인</li>
  *   <li><b>에러번호 (3자리)</b>: 도메인 내 개별 에러 식별 번호</li>
  * </ul>
- *
+ * <p>
  * 예: <code>OSAEK-10001</code> → 회원 도메인(10)에서 정의한 첫 번째 에러
  */
 @Getter
@@ -55,7 +55,11 @@ public enum ClientErrorCode implements BaseErrorCode {
 	OAUTH_PASSWORD_CANT_CHANGE(HttpStatus.NOT_ACCEPTABLE, "OSAEK-10217", "password.cant_change"),
 
 	// 지역 코드 관련
-	AREA_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "OSAEK-10009", "area.code.not_found");
+	AREA_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "OSAEK-30009", "area.code.not_found"),
+
+	// 축제 관련
+	FESTIVAL_ID_NULL(HttpStatus.BAD_REQUEST, "OSAEK-30001", "festival.id.null"),
+	FESTIVAL_ID_INVALID(HttpStatus.BAD_REQUEST, "OSAEK-3002", "festival.id.invalid");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/oseak/myFestaBackend/dto/response/FestivalDetailResponseDto.java
+++ b/src/main/java/com/oseak/myFestaBackend/dto/response/FestivalDetailResponseDto.java
@@ -1,0 +1,89 @@
+package com.oseak.myFestaBackend.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.oseak.myFestaBackend.entity.Festa;
+import com.oseak.myFestaBackend.entity.enums.FestaStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "축제 상세 조회 결과")
+public class FestivalDetailResponseDto {
+
+	@Schema(description = "축제 ID", example = "30")
+	private Long festaId;
+
+	@Schema(description = "컨텐츠 ID", example = "3481597")
+	private Long contentId;
+
+	@Schema(description = "축제명", example = "페인터즈")
+	private String festaName;
+
+	@Schema(description = "위도", example = "37.5681316804")
+	private Double latitude;
+
+	@Schema(description = "경도", example = "126.9696495605")
+	private Double longitude;
+
+	@Schema(description = "축제 주소", example = "서울특별시 중구 정동길 3 (정동)")
+	private String festaAddress;
+
+	@Schema(description = "축제 시작 일시", example = "2022-11-01T00:00:00")
+	private LocalDateTime festaStartAt;
+
+	@Schema(description = "축제 종료 일시", example = "2025-12-31T00:00:00")
+	private LocalDateTime festaEndAt;
+
+	@Schema(description = "지역 코드", example = "1")
+	private Integer areaCode;
+
+	@Schema(description = "세부 지역 코드", example = "24")
+	private Integer subAreaCode;
+
+	@Schema(description = "개요", example = "2008년 초연된 페인터즈는 화려한 안무와 라이브 드로잉...")
+	private String overview;
+
+	@Schema(description = "상세 설명", example = "페인터즈는 관객과 소통하는 주요 매개가 춤과 연기...")
+	private String description;
+
+	@Schema(description = "이미지 URL", example = "http://tong.visitkorea.or.kr/cms/resource/...")
+	private String imageUrl;
+
+	@Schema(description = "운영 시간", example = "10:00-18:00")
+	private String openTime;
+
+	@Schema(description = "요금 정보", example = "성인 15,000원, 청소년 12,000원")
+	private String feeInfo;
+
+	@Schema(description = "축제 상태", example = "ONGOING")
+	private FestaStatus festaStatus;
+
+	public static FestivalDetailResponseDto from(Festa festival) {
+		return FestivalDetailResponseDto.builder()
+			.festaId(festival.getFestaId())
+			.contentId(festival.getContentId())
+			.festaName(festival.getFestaName())
+			.latitude(festival.getLatitude())
+			.longitude(festival.getLongitude())
+			.festaAddress(festival.getFestaAddress())
+			.festaStartAt(festival.getFestaStartAt())
+			.festaEndAt(festival.getFestaEndAt())
+			.areaCode(festival.getAreaCode())
+			.subAreaCode(festival.getSubAreaCode())
+			.overview(festival.getOverview())
+			.description(festival.getDescription())
+			.imageUrl(festival.getImageUrl())
+			.openTime(festival.getOpenTime())
+			.feeInfo(festival.getFeeInfo())
+			.festaStatus(festival.getFestaStatus())
+			.build();
+	}
+}

--- a/src/main/java/com/oseak/myFestaBackend/service/FestaService.java
+++ b/src/main/java/com/oseak/myFestaBackend/service/FestaService.java
@@ -1,5 +1,7 @@
 package com.oseak.myFestaBackend.service;
 
+import static com.oseak.myFestaBackend.common.exception.code.ServerErrorCode.*;
+
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -31,6 +33,7 @@ import com.oseak.myFestaBackend.common.exception.code.ServerErrorCode;
 import com.oseak.myFestaBackend.dto.FestaSimpleDto;
 import com.oseak.myFestaBackend.dto.FestaSummaryDto;
 import com.oseak.myFestaBackend.dto.request.FestivalSearchRequest;
+import com.oseak.myFestaBackend.dto.response.FestivalDetailResponseDto;
 import com.oseak.myFestaBackend.dto.response.FestivalSearchItem;
 import com.oseak.myFestaBackend.entity.Festa;
 import com.oseak.myFestaBackend.entity.enums.FestaStatus;
@@ -328,6 +331,27 @@ public class FestaService {
 
 		Page<Festa> page = festaRepository.findAll(spec, pageable);
 		return page.map(FestivalSearchItem::from);
+	}
+
+	/**
+	 * 축제 상세 정보 조회
+	 *
+	 * @param id 축제 ID
+	 * @return FestivalDetailResponseDto 축제 상세 정보
+	 */
+	public FestivalDetailResponseDto getDetail(Long id) {
+		log.debug("축제 상세 정보 조회 시작: id={}", id);
+
+		Festa festival = festaRepository.findById(id)
+			.orElseThrow(() -> {
+				log.warn("축제를 찾을 수 없습니다: id={}", id);
+				return new OsaekException(FESTA_NOT_FOUND);
+			});
+
+		FestivalDetailResponseDto responseDto = FestivalDetailResponseDto.from(festival);
+
+		log.debug("축제 상세 정보 조회 완료: id={}, name={}", id, festival.getFestaName());
+		return responseDto;
 	}
 
 }


### PR DESCRIPTION
db에서 관리하는 PK로 축제 id를 조회하여 단건의 축제 정보를 상세조회 할 수 있도록 기능을 구현하였습니다.
