### PR TITLE
docs: @OpenAPIDefinition 추가

### DIFF
--- a/src/main/java/com/oseak/myFestaBackend/FestabackendApplication.java
+++ b/src/main/java/com/oseak/myFestaBackend/FestabackendApplication.java
@@ -3,7 +3,12 @@ package com.oseak.myFestaBackend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
+@OpenAPIDefinition(
+	servers = {
+		@Server(url = "/api", description = "Default API"),
+		@Server(url = "http://localhost:8080", description = "Local Dev"),
+	}
+)
 @SpringBootApplication
 @EnableScheduling   //배치 활성화
 public class FestabackendApplication {


### PR DESCRIPTION
localhost:8080(개발환경)을 제외한 기본 요청은 모두 /api를 붙이도록 함