### PR TITLE
스토리 정보에 nickname 추가 

### DIFF
--- a/src/main/java/com/oseak/myFestaBackend/common/util/SecurityUtil.java
+++ b/src/main/java/com/oseak/myFestaBackend/common/util/SecurityUtil.java
@@ -39,6 +39,17 @@ public class SecurityUtil {
 		return getCurrentUser().getMemberId();
 	}
 
+	public static Long getCurrentUserIdOrNull() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+			CustomUserDetails userDetails = (CustomUserDetails)authentication.getPrincipal();
+			return userDetails.getMemberId();
+		}
+
+		return null;
+	}
+
 	public static Member getCurrentMember() {
 		return getCurrentUser().getMember();
 	}

--- a/src/main/java/com/oseak/myFestaBackend/dto/response/StoryItem.java
+++ b/src/main/java/com/oseak/myFestaBackend/dto/response/StoryItem.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 public class StoryItem {
 	private String storyCode;
 	private Long memberId;
+	private String nickname;
 	private Boolean isOpen;
 	private String thumbnailUrl;
 	private String festaName;
@@ -20,10 +21,11 @@ public class StoryItem {
 	private String storyS3Url;
 	private LocalDateTime createdAt;
 
-	public static StoryItem from(Story story) {
+	public static StoryItem from(Story story, String nickname) {
 		return StoryItem.builder()
 			.storyCode(ShortCodeUtil.encode(story.getStoryId()))
 			.memberId(story.getMemberId())
+			.nickname(nickname)
 			.isOpen(story.getIsOpen())
 			.thumbnailUrl(story.getThumbnailUrl())
 			.storyS3Url(story.getStoryS3Url())

--- a/src/main/java/com/oseak/myFestaBackend/facade/StoryFacade.java
+++ b/src/main/java/com/oseak/myFestaBackend/facade/StoryFacade.java
@@ -1,0 +1,61 @@
+package com.oseak.myFestaBackend.facade;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.oseak.myFestaBackend.dto.request.StorySearchRequestDto;
+import com.oseak.myFestaBackend.dto.request.StoryUploadRequestDto;
+import com.oseak.myFestaBackend.dto.request.StoryVisibilityUpdateRequestDto;
+import com.oseak.myFestaBackend.dto.response.StoryItem;
+import com.oseak.myFestaBackend.entity.Story;
+import com.oseak.myFestaBackend.service.MemberService;
+import com.oseak.myFestaBackend.service.StoryService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StoryFacade {
+
+	private final StoryService storyService;
+	private final MemberService memberService;
+
+	public Page<StoryItem> searchStories(StorySearchRequestDto request, Long viewerMemberId) {
+		Page<Story> storyPage = storyService.searchStories(request, viewerMemberId);
+		return storyPage.map(story -> {
+			String nickname = memberService.getNicknameByMemberId(story.getMemberId());
+			return StoryItem.from(story, nickname);
+		});
+	}
+
+	public StoryItem getStory(String storyCode, Long requesterMemberId) {
+		Story story = storyService.getStoryEntity(storyCode, requesterMemberId);
+		String nickname = memberService.getNicknameByMemberId(story.getMemberId());
+		return StoryItem.from(story, nickname);
+	}
+
+	public StoryItem updateStoryVisibility(StoryVisibilityUpdateRequestDto request, Long requesterId) {
+		Story story = storyService.updateStoryVisibilityEntity(request, requesterId);
+		String nickname = memberService.getNicknameByMemberId(story.getMemberId());
+		return StoryItem.from(story, nickname);
+	}
+
+	public void softDeleteStory(String storyCode, Long requesterMemberId) {
+		storyService.softDeleteStory(storyCode, requesterMemberId);
+	}
+
+	public void deleteStory() {
+		storyService.deleteStory();
+	}
+
+	public Story uploadStory(MultipartFile file, Long memberId) {
+		return storyService.uploadStory(file, memberId);
+	}
+
+	public StoryItem uploadStoryAsync(StoryUploadRequestDto requestDto, Long memberId) {
+		Story story = storyService.uploadStoryAsyncEntity(requestDto, memberId);
+		String nickname = memberService.getNicknameByMemberId(story.getMemberId());
+		return StoryItem.from(story, nickname);
+	}
+}

--- a/src/main/java/com/oseak/myFestaBackend/service/MemberService.java
+++ b/src/main/java/com/oseak/myFestaBackend/service/MemberService.java
@@ -108,4 +108,10 @@ public class MemberService {
 			.message("Password changed successfully!")
 			.build();
 	}
+
+	public String getNicknameByMemberId(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new OsaekException(USER_ID_NOT_FOUND));
+		return member.getNickname();
+	}
 }


### PR DESCRIPTION
- 2개의 서비스를 사용해야하므로 Facade 계층 사용
- 스토리 조회는 비로그인 사용자도 가능하도록 변경